### PR TITLE
Add 'tree_string' for debug

### DIFF
--- a/lib/mlibrary_search_parser/node/base.rb
+++ b/lib/mlibrary_search_parser/node/base.rb
@@ -51,13 +51,32 @@ module MLibrarySearchParser::Node
     # Default implementation just returns the string with optional
     # parens
     # @return [String] the clean string representation of the subtree
-    def to_clean_string
+    def clean_string
       parenthesize_multiwords(to_s)
     end
 
     # Is this the root node?
     def root_node?
       parent.nil?
+    end
+
+    # How far down are we?
+    # @return [Integer] depth from the root (where root is 0)
+    def depth
+      if root_node?
+        0
+      else
+        1 + parent.depth
+      end
+    end
+
+    # Just an indent for printing the tree
+    def tree_indent
+      if depth.zero?
+        ""
+      else
+        parent.tree_indent + "  ┝  "
+      end
     end
 
     # Get the immediate children -- nothing for leaves, left/right

--- a/lib/mlibrary_search_parser/node/boolean.rb
+++ b/lib/mlibrary_search_parser/node/boolean.rb
@@ -52,13 +52,17 @@ module MLibrarySearchParser
         "(#{left}) #{operator.upcase} (#{right})"
       end
 
-      def to_clean_string
-        cs = "#{left.to_clean_string} #{operator.upcase} #{right.to_clean_string}"
+      def clean_string
+        cs = "#{left.clean_string} #{operator.upcase} #{right.clean_string}"
         if root_node?
           cs
         else
           "(#{cs})"
         end
+      end
+
+      def tree_string
+        ["#{tree_indent}#{operator.to_s.upcase}", left.tree_string, right.tree_string].join("\n")
       end
 
       def trim(&blk)
@@ -150,6 +154,10 @@ module MLibrarySearchParser
 
       def to_s
         "#{operator.upcase} (#{operand})"
+      end
+
+      def tree_string
+        "#{tree_indent}#{operator.to_s.upcase}\n#{operand.tree_string}"
       end
 
       def deep_dup(&blk)

--- a/lib/mlibrary_search_parser/node/empty.rb
+++ b/lib/mlibrary_search_parser/node/empty.rb
@@ -8,6 +8,10 @@ module MLibrarySearchParser::Node
       # nothing; just overriding
     end
 
+    def tree_string
+      "#{tree_indent}<EMPTY>"
+    end
+
     def inspect
       "<EmptyNode>"
     end

--- a/lib/mlibrary_search_parser/node/fielded.rb
+++ b/lib/mlibrary_search_parser/node/fielded.rb
@@ -20,6 +20,8 @@ module MLibrarySearchParser
         [query]
       end
 
+
+
       def deep_dup(&blk)
         n = self.class.new(field, query.deep_dup(&blk))
         if block_given?
@@ -37,8 +39,12 @@ module MLibrarySearchParser
         "#{field}:(#{query})"
       end
 
-      def to_clean_string
-        "#{field}:#{query.to_clean_string}"
+      def clean_string
+        "#{field}:#{query.clean_string}"
+      end
+
+      def tree_string
+        "#{tree_indent}<#{field}>\n#{query.tree_string}"
       end
 
       def inspect

--- a/lib/mlibrary_search_parser/node/fielded.rb
+++ b/lib/mlibrary_search_parser/node/fielded.rb
@@ -44,7 +44,7 @@ module MLibrarySearchParser
       end
 
       def tree_string
-        "#{tree_indent}<#{field}>\n#{query.tree_string}"
+        "#{tree_indent}FIELD: #{field}\n#{query.tree_string}"
       end
 
       def inspect

--- a/lib/mlibrary_search_parser/node/search.rb
+++ b/lib/mlibrary_search_parser/node/search.rb
@@ -44,8 +44,18 @@ module MLibrarySearchParser::Node
       clauses.join(" | ")
     end
 
-    def to_clean_string
-      clauses.map(&:to_clean_string).join(' ')
+    def clean_string
+      clauses.map(&:clean_string).join(' ')
+    end
+
+    # Since the search node is just a holder for multiple clauses,
+    # we don't count it as deepening the tree
+    def depth
+      super - 1
+    end
+
+    def tree_string
+      clauses.map(&:tree_string).join("\n")
     end
 
     def inspect

--- a/lib/mlibrary_search_parser/node/tokens.rb
+++ b/lib/mlibrary_search_parser/node/tokens.rb
@@ -45,6 +45,9 @@ module MLibrarySearchParser::Node
       self
     end
 
+    def tree_string
+      "#{tree_indent}#{clean_string}"
+    end
 
     def inspect
       "<TokensNode: [#{text}]>"

--- a/spec/node/boolean_spec.rb
+++ b/spec/node/boolean_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe "BooleanNode" do
     end
 
     it "produces a clean string with multi terms" do
-      expect(@node.to_clean_string).to eq("(left terms) AND (right terms)")
+      expect(@node.clean_string).to eq("(left terms) AND (right terms)")
     end
 
     it "produces a clean string with single terms" do
-      expect(@genericAnd.to_clean_string).to eq("left AND (right right)")
+      expect(@genericAnd.clean_string).to eq("left AND (right right)")
     end
 
     it "has two children" do

--- a/spec/node/fielded_spec.rb
+++ b/spec/node/fielded_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe "FieldedNode" do
   end
 
   it "has a simple to_clean_string" do
-    expect(fielded_node('title', 'one').to_clean_string).to eq("title:one")
+    expect(fielded_node('title', 'one').clean_string).to eq("title:one")
   end
 
   it "has multi-term to_clean_string" do
-    expect(@node.to_clean_string).to eq("title:(some terms)")
+    expect(@node.clean_string).to eq("title:(some terms)")
   end
 
   it "has a more complex to_clean_string" do
     n = and_node(fielded_node('title', and_node('one', 'two')), fielded_node("author", '"phrase here"'))
-    expect(n.to_clean_string).to eq('title:(one AND two) AND author:("phrase here")')
+    expect(n.clean_string).to eq('title:(one AND two) AND author:("phrase here")')
   end
 
   it "has to_webform" do

--- a/spec/node/search_spec.rb
+++ b/spec/node/search_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "SearchNode" do
 
   describe "Basics" do
     it "stringifies" do
-      expect(@simple.to_clean_string).to eq "one"
-      expect(@fielded.to_clean_string).to eq "title:two"
-      expect(@simple_multi.to_clean_string).to eq "one two three"
-      expect(@complex.to_clean_string).to eq "(one AND two) (three OR four)"
+      expect(@simple.clean_string).to eq "one"
+      expect(@fielded.clean_string).to eq "title:two"
+      expect(@simple_multi.clean_string).to eq "one two three"
+      expect(@complex.clean_string).to eq "(one AND two) (three OR four)"
     end
 
     it "provides equality" do
@@ -31,7 +31,7 @@ RSpec.describe "SearchNode" do
 
     it "deep_dups with a block" do
       dup = @complex.deep_dup {|n| n.is_type?(:or) ? tnode("XXX") : n }
-      expect(dup.to_clean_string).to eq "(one AND two) XXX"
+      expect(dup.clean_string).to eq "(one AND two) XXX"
     end
 
   end

--- a/spec/node/tokens_spec.rb
+++ b/spec/node/tokens_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "TokensNode" do
   end
 
   it "parenthesizes multiple words" do
-    expect(@node.to_clean_string).to eq "(some text)"
+    expect(@node.clean_string).to eq "(some text)"
   end
 
   it "recognizes equality of itself" do


### PR DESCRIPTION
minor change: Change `to_clean_string` to just `clean_string`. Was driving me crazy.

Added `#tree_string` to all the node types, to produce debug
output like this:

```
[107] pry(main)> puts y.tree_string
AND
  ┝  AND
  ┝    ┝  one
  ┝    ┝  OR
  ┝    ┝    ┝  two
  ┝    ┝    ┝  three
  ┝  FIELD: title
  ┝    ┝  (four five)
```
