### PR TITLE
A few conveniences

### DIFF
--- a/lib/mlibrary_search_parser/node/base.rb
+++ b/lib/mlibrary_search_parser/node/base.rb
@@ -195,6 +195,11 @@ module MLibrarySearchParser::Node
       %Q("#{tokens_string.gsub('"', '')}")
     end
 
+    # Get only the tokens the user actually wants
+    def wanted_tokens_string
+      deep_dup.trim_not.tokens_string
+    end
+
     # Assign each node in this tree an arbitrary number, useful for
     # splitting out extra query information in a way you know will
     # be unique for each node.

--- a/lib/mlibrary_search_parser/node/search.rb
+++ b/lib/mlibrary_search_parser/node/search.rb
@@ -40,6 +40,10 @@ module MLibrarySearchParser::Node
       end
     end
 
+    def trim(&blk)
+      self.class.new(clauses.map{|c| c.trim(&blk)})
+    end
+
     def to_s
       clauses.join(" | ")
     end

--- a/lib/mlibrary_search_parser/search.rb
+++ b/lib/mlibrary_search_parser/search.rb
@@ -64,11 +64,27 @@ module MLibrarySearchParser
     end
   end
 
+  class SearchBuilder
+    attr_accessor :config
+
+    def initialize(config)
+      @config = config
+    end
+
+    def build(original_input)
+      Search.new(original_input, config)
+    end
+  end
+
   class Search
     attr_reader :search_tree, :original_input, :mini_search, :config
     # could come from search box, from adv search form, or from solr output
 
     def self.from_form(input, search_handler) end
+    
+    def self.search_builder(config)
+      SearchBuilder.new(config)
+    end
 
     def initialize(original_input, config)
       @original_input = original_input

--- a/lib/mlibrary_search_parser/transform/solr/local_params.rb
+++ b/lib/mlibrary_search_parser/transform/solr/local_params.rb
@@ -16,17 +16,21 @@ module MLibrarySearchParser
           end
         end
 
+
         # @param [MLibrarySearchParser::Node::BaseNode] node
         def edismaxify(field, node)
           q_localparams_name  = "q#{node.number}"
           qq_localparams_name = "qq#{node.number}"
+          tokens_name         = "t#{node.number}"
 
           add_param(q_localparams_name, node.clean_string)
           add_param(qq_localparams_name, node.tokens_phrase)
+          add_param(tokens_name, node.wanted_tokens_string)
 
           args = field_config(field).each_pair.map do |k, v|
-            v = v.to_s.gsub(/\$q\b/, "$"+q_localparams_name)
-            v = v.gsub(/\$qq\b/, "$"+qq_localparams_name)
+            v = v.to_s.gsub(/\$q\b/, "$" + q_localparams_name)
+            v = v.gsub(/\$qq\b/, "$" + qq_localparams_name)
+            v = v.gsub(/\$t\b/, "$" + tokens_name)
             v = v.gsub(/[\n\s]+/, ' ')
             "#{k}=\"#{v}\""
           end

--- a/lib/mlibrary_search_parser/transform/solr/solr_search.rb
+++ b/lib/mlibrary_search_parser/transform/solr/solr_search.rb
@@ -18,7 +18,7 @@ module MLibrarySearchParser
         # @param [MLibrarySearchParser::Search] search
         def initialize(search)
           @original_search_tree = search
-          @search_tree = lucene_escape_node(search.search_tree.deep_dup)
+          @search_tree          = lucene_escape_node(search.search_tree.deep_dup)
           @search_tree.renumber!
           @params = {}
           @query  = {}
@@ -27,7 +27,11 @@ module MLibrarySearchParser
         end
 
         def transform!
-          @query = transform(search_tree)
+          if ['', '*'].include? @original_search_tree.clean_string.strip
+            add_param('q', '*:*')
+          else
+            @query = transform(search_tree)
+          end
         end
 
         def default_field

--- a/spec/node/search_spec.rb
+++ b/spec/node/search_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe "SearchNode" do
       expect(dup.clean_string).to eq "(one AND two) XXX"
     end
 
+    it "finds wanted tokens" do
+      neg = search_node(and_node("one", or_node(not_node(tnode("two")), tnode("three"))))
+      expect(neg.wanted_tokens_string).to eq "one three"
+    end
+
   end
 
 end

--- a/spec/search_spec.rb
+++ b/spec/search_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe "Search" do
         it "returns solr query" do
             expect(@search.to_solr_query).to eq "a simple search"
         end
+
+        it "constructs a factory" do
+          search_builder = MLibrarySearchParser::Search.search_builder(@config)
+          search         = search_builder.build("a simple search")
+          expect(search.to_s).to eq("a simple search")
+        end
     end
 
     describe "a query AND some more query" do


### PR DESCRIPTION
A few conveniences:
* SearchBuilder to make a factory out of a config
* #wanted_tokens_string to get a string of all the 
  tokens _not_ in a NOT subtree
* Do substitutions in localparams for all q, qq, and t variables
* Change LocalParams to just give "q=*:*" on empty string
  or a search of "*"
﻿
