### PR TITLE
Send details upstream

### DIFF
--- a/lib/mlibrary_search_parser/search_handler.rb
+++ b/lib/mlibrary_search_parser/search_handler.rb
@@ -14,6 +14,14 @@ module MLibrarySearchParser
     def details
       self.class::DETAILS
     end
+
+    def to_h
+      {
+        details: details,
+        original: original,
+        actual: actual,
+      }
+    end
   end
 
   class UnevenParensError < ParseError


### PR DESCRIPTION
Send a detailed message upstream about the nature of the parse error,
the original search string and the actual search string.