### PR TITLE
Eliminate mm from boolean edismax clauses

### DIFF
--- a/lib/mlibrary_search_parser/transform/solr/local_params.rb
+++ b/lib/mlibrary_search_parser/transform/solr/local_params.rb
@@ -49,8 +49,17 @@ module MLibrarySearchParser
           end
 
           args = default_attributes.merge(args)
-          arg_pairs = args.each_pair.map{|k, v| "#{k}=#{v}"}
 
+          # If the node is a boolean, we need to get rid of the mm parameter
+          # because edismax with bools and mm just don't play well together.
+          #
+          # See https://blog.innoventsolutions.com/innovent-solutions-blog/2017/02/solr-edismax-boolean-query.html
+          # and/or SOLR-8812
+
+          if [:and, :or].include? node.node_type
+             args.delete('mm')
+          end
+          arg_pairs = args.each_pair.map{|k, v| "#{k}=#{v}"}
           "{!edismax #{arg_pairs.join(' ')} v=$#{q_localparams_name}}"
         end
 

--- a/spec/data/00-catalog.yml
+++ b/spec/data/00-catalog.yml
@@ -74,12 +74,16 @@ search_fields:
     qf: series^200 series2^50
 
   serial_title:
-    pf: serialTitle_common_exact^600 serialTitle_common_l^300 serialTitle_common^100 serialTitle_a_exact^200 serialTitle_equiv^250
+    pf: serialTitle_common_exact^600 serialTitle_common_l^300 serialTitle_common^100 serialTitle_a_exact^40  serialTitle_equiv^20
     qf: serialTitle_common^30 serialTitle_equiv^15 serialTitle_rest^10
 
   journal_title:
-    pf: serialTitle_ab^25000 serialTitle_a^15000 serialTitleProper^1200
-    qf: serialTitleProper^120  serialTitle^30 serialTitle_rest^10
+    pf: serialTitle_common_exact^600 serialTitle_common_l^300 serialTitle_common^100 serialTitle_a_exact^40  serialTitle_equiv^20
+    qf: serialTitle_common^30 serialTitle_equiv^15 serialTitle_rest^10
+
+#  journal_title:
+#    pf: serialTitle_ab^25000 serialTitle_a^15000 serialTitleProper^1200
+#    qf: serialTitleProper^120  serialTitle^30 serialTitle_rest^10
 
   subject:
     pf: topicProper^5 topic^1 fullgeographic^1 fullgenre^1 era^1
@@ -98,8 +102,8 @@ search_fields:
     qf: authorStr^1
 
   isn:
-    pf: issn isbn barcode lccn oclc sdrnum ctrlnum ht_id isn_related rptnum id id_int
-    qf: issn isbn barcode lccn oclc sdrnum ctrlnum ht_id isn_related rptnum id id_int
+    pf: issn^10 isbn^10 lccn^5 oclc^5 sdrnum^2 isn_related^2 rptnum ctrlnum ht_id  id id_int barcode
+    qf: issn^10 isbn^10 lccn^5 oclc^5 sdrnum^2 isn_related^2 rptnum ctrlnum ht_id  id id_int barcode
 
   publisher:
     pf: publisher^10

--- a/spec/solr_transforms/localparams_spec.rb
+++ b/spec/solr_transforms/localparams_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../spec_helper'
+require 'mlibrary_search_parser/transform/solr/local_params'
+
+
+# Build up a localparams object based on the given search string
+
+def localparams(str)
+  search = catalog_search(str)
+  MLibrarySearchParser::Transformer::Solr::LocalParams.new(search)
+end
+
+RSpec.describe MLibrarySearchParser::Transformer::Solr::LocalParams do
+
+  describe "Correctly use mm with/without booleans" do
+    it "adds mm for non-boolean search" do
+      lp = localparams("one two")
+      expect(lp.query).to match(/mm=\$default_mm/)
+    end
+
+    it "doesn't add mm for boolean search" do
+      lp = localparams("one AND two")
+      expect(lp.query).to_not match(/mm=\$default_mm/)
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,15 @@ RSpec.configure do |config|
   end
 end
 
+# Set up a search builder based on the catalog
+catalog_config_file = './spec/data/00-catalog.yml'
+catalog_config      = YAML.load(ERB.new(File.read(catalog_config_file)).result)
+CATALOG_SEARCH_BUILDER = MLibrarySearchParser::Search.search_builder(catalog_config)
+
+def catalog_search(search_str)
+  CATALOG_SEARCH_BUILDER.build(search_str)
+end
+
 def nodeify(node_or_string)
   if node_or_string.kind_of? MLibrarySearchParser::Node::BaseNode
     node_or_string


### PR DESCRIPTION
Booleans and mm in edismax don't get along. In localparams, check to see if a
node_type is :or or :and and remove the 'mm' parameter.

This commit:
  * Removes the 'mm' parameter from localparams edismax when it contains a boolean node
  * Adds a new spec_helper, `catalog_search(search_str)` for convenience
  * Updates the 00-catalog.yml file for testing

Refs:
  * https://blog.innoventsolutions.com/innovent-solutions-blog/2017/02/solr-edismax-boolean-query.html
  * SOLR-8812