### PR TITLE
Ensure all errors receive the true original string

### DIFF
--- a/spec/search_handler_spec.rb
+++ b/spec/search_handler_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe "MLibrarySearchHandler" do
         expect(err.original).to eq 'test) "with title:(author:many problems) AND '
       end
     end
+
+    it "preserves original search string" do
+      search = MLibrarySearchParser::MiniSearch.new("keyword AND ")
+      output = @handler.pre_process(search)
+      expect(output.errors).to match_array(MLibrarySearchParser::UnparseableError)
+      expect(output.errors[0].original).to eq "keyword AND "
+    end
   end
 
   describe "parse" do

--- a/spec/search_handler_spec.rb
+++ b/spec/search_handler_spec.rb
@@ -104,14 +104,18 @@ RSpec.describe "MLibrarySearchHandler" do
     end
 
     it "collects multiple errors where applicable" do
-      search = MLibrarySearchParser::MiniSearch.new('test) "with title:(author:many problems)')
+      search = MLibrarySearchParser::MiniSearch.new('test) "with title:(author:many problems) AND ')
       output = @handler.pre_process(search)
-      expect(output.to_s).to eq "test with title:author many problems"
+      expect(output.to_s).to eq "test with title:author many problems AND "
       expect(output.errors).to match_array([
         MLibrarySearchParser::UnevenQuotesError,
         MLibrarySearchParser::UnevenParensError,
-        MLibrarySearchParser::NestedFieldsError
+        MLibrarySearchParser::NestedFieldsError,
+        MLibrarySearchParser::UnparseableError
       ])
+      for err in output.errors do
+        expect(err.original).to eq 'test) "with title:(author:many problems) AND '
+      end
     end
   end
 


### PR DESCRIPTION
This is to deal with the "picasso AND (" incorrect error message issue. The problem was that the pre-processor sends each newly cleaned string to the next step. These changes mean that although the search string gets cleaned up with each step, the original string is preserved for the error messages.