### PR TITLE
Change parser infrastructure to deal with asterisks as wildcards

### DIFF
--- a/lib/mlibrary_search_parser/node/boolean.rb
+++ b/lib/mlibrary_search_parser/node/boolean.rb
@@ -99,11 +99,17 @@ module MLibrarySearchParser
 
       # Shake out stuff like title:one AND title:two to title:(one AND two)
       def shake
+        lshake = left.shake
+        rshake = right.shake
+
+        return EmptyNode.new if  [lshake, rshake].all? {|n| n.is_type?(:empty)}
+        return lshake if rshake.is_type?(:empty)
+        return rshake if lshake.is_type?(:empty)
         if [left,right].all? {|x| x.is_type?(:fielded)} and
             left.field == right.field
           FieldedNode.new(left.field, self.class.new(left.query.shake, right.query.shake))
-        elsif left.shake == right.shake
-          left.shake
+        elsif lshake == rshake
+          lshake
         else
           self
         end

--- a/lib/mlibrary_search_parser/node/fielded.rb
+++ b/lib/mlibrary_search_parser/node/fielded.rb
@@ -20,7 +20,14 @@ module MLibrarySearchParser
         [query]
       end
 
-
+      def shake
+        shaken = query.shake
+        if shaken.is_type?(:empty)
+          EmptyNode.new
+        else
+          self.class.new(field, shaken)
+        end
+      end
 
       def deep_dup(&blk)
         n = self.class.new(field, query.deep_dup(&blk))
@@ -52,7 +59,7 @@ module MLibrarySearchParser
       end
 
       def to_webform
-        [{"field" => field}, query.to_webform]
+        [{ "field" => field }, query.to_webform]
       end
     end
   end

--- a/lib/mlibrary_search_parser/node/search.rb
+++ b/lib/mlibrary_search_parser/node/search.rb
@@ -28,7 +28,7 @@ module MLibrarySearchParser::Node
     end
 
     def shake
-      self.class.new(clauses.map(&:shake))
+      self.class.new(clauses.map(&:shake).reject{|x| x.is_type?(:empty)})
     end
 
     def deep_dup(&blk)

--- a/lib/mlibrary_search_parser/node/tokens.rb
+++ b/lib/mlibrary_search_parser/node/tokens.rb
@@ -42,7 +42,11 @@ module MLibrarySearchParser::Node
     end
 
     def shake
-      self
+      if text == '*'
+        EmptyNode.new
+      else
+        self
+      end
     end
 
     def tree_string

--- a/lib/mlibrary_search_parser/search.rb
+++ b/lib/mlibrary_search_parser/search.rb
@@ -98,9 +98,12 @@ module MLibrarySearchParser
     def clean_string
       search_tree.clean_string
     end
-
     def search_tree
       @search_tree ||= @search_handler.parse(mini_search.to_s)
+    end
+
+    def shake
+      @search_tree = search_tree.shake
     end
 
     def valid?

--- a/lib/mlibrary_search_parser/transform/solr/solr_search.rb
+++ b/lib/mlibrary_search_parser/transform/solr/solr_search.rb
@@ -17,7 +17,7 @@ module MLibrarySearchParser
 
         # @param [MLibrarySearchParser::Search] search
         def initialize(search)
-          @original_search_tree = search
+          @original_search_tree = search.shake
           @search_tree          = lucene_escape_node(search.search_tree.deep_dup)
           @search_tree.renumber!
           @params = {}

--- a/spec/query_parser_spec.rb
+++ b/spec/query_parser_spec.rb
@@ -201,4 +201,9 @@ RSpec.describe MLibrarySearchParser do
     expect(parse_and_transform(str).clean_string).to eq "subject:(Moscow (Russia) History)"
   end
 
+  it "leaves asterisks for wildcards alone" do
+    str = "title:one wildcard*"
+    expect(parse_and_transform(str).clean_string).to eq "title:(one wildcard*)"
+  end
+
 end

--- a/spec/solr_transforms/localparams_spec.rb
+++ b/spec/solr_transforms/localparams_spec.rb
@@ -1,7 +1,6 @@
 require_relative '../spec_helper'
 require 'mlibrary_search_parser/transform/solr/local_params'
 
-
 # Build up a localparams object based on the given search string
 
 def localparams(str)
@@ -20,6 +19,24 @@ RSpec.describe MLibrarySearchParser::Transformer::Solr::LocalParams do
     it "doesn't add mm for boolean search" do
       lp = localparams("one AND two")
       expect(lp.query).to_not match(/mm=\$default_mm/)
+    end
+  end
+
+  describe "correctly deals with asterisks for wildcard search" do
+    it "doesn't escape the end of a word" do
+      lp = localparams("wildcard*")
+      q = lp.query
+      expect(lp.params[:q1]).to eq('wildcard*')
+    end
+
+    it "doesn't escape with multiple words" do
+      lp = localparams('one wildcard* two')
+      expect(lp.params[:q1]).to eq("(one wildcard* two)")
+    end
+
+    it "does escape in the middle of a word" do
+      lp = localparams("title:one two*three four*")
+      expect(lp.params[:q2]).to eq('(one two\\*three four*)')
     end
   end
 

--- a/spec/solr_transforms/localparams_spec.rb
+++ b/spec/solr_transforms/localparams_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe MLibrarySearchParser::Transformer::Solr::LocalParams do
       lp = localparams("title:one two*three four*")
       expect(lp.params[:q2]).to eq('(one two\\*three four*)')
     end
+
+    it "handles the single-asterisk search" do
+      lp = localparams("*")
+      expect(lp.params[:q]).to eq("*:*")
+    end
+  end
+
+  describe "shakes" do
+    it "combines matching fieldeds into one" do
+      lp = localparams('title:one AND title:two')
+      expect(lp.params[:clean_string]).to eq('title:(one AND two)')
+    end
   end
 
 end

--- a/t.rb
+++ b/t.rb
@@ -8,7 +8,7 @@ require 'erb'
 
 
 # Your solr port (local) or full URL (remote)
-portOrURL = 'http://julep-1.umdl.umich.edu:8026/solr'
+portOrURL = 'http://julep-1.umdl.umich.edu:8023/solr'
 # portOrURL = 9639
 client = SimpleSolrClient::Client.new(portOrURL)
 @core = client.core(client.cores.first)


### PR DESCRIPTION
Change parser infrastructure to deal with asterisks as wildcards

This includes three things:
  * Change the lucene_escape utility to only escape an asterisk
    if it doesn't appear at the end of a word (e.g., with a 
    unicode letter or number before it and only whitespace
    allowed after it)
  * Add code to the various `#shake` methods on the nodes
    to find empty nodes and remove them in valid ways
  * Make sure to shake the tree before doing the solr transform.