### PR TITLE
Fix error trying to shake a tree containing NOT nodes

### DIFF
--- a/lib/mlibrary_search_parser/node/boolean.rb
+++ b/lib/mlibrary_search_parser/node/boolean.rb
@@ -183,6 +183,13 @@ module MLibrarySearchParser
         "<#{operator.upcase} [#{operand.inspect}]>"
       end
 
+      def shake
+        shaken = operand.shake
+
+        return EmptyNode.new if  shaken.is_type?(:empty)
+        self.class.new(shaken)
+      end
+
       def to_webform
         [{"operator" => "#{operator.upcase}"}, operand.to_webform]
       end

--- a/spec/solr_transforms/localparams_spec.rb
+++ b/spec/solr_transforms/localparams_spec.rb
@@ -50,6 +50,16 @@ RSpec.describe MLibrarySearchParser::Transformer::Solr::LocalParams do
       lp = localparams('title:one AND title:two')
       expect(lp.params[:clean_string]).to eq('title:(one AND two)')
     end
+
+    it "shakes a NOT" do
+      lp = localparams('subject:one NOT subject:two')
+      expect(lp.params[:clean_string]).to eq('subject:one (NOT (subject:(two)))')
+    end
+
+    it "shakes an AND" do
+      lp = localparams('one AND two')
+      expect(lp.params[:clean_string]).to eq('(one AND two)')
+    end
   end
 
 end


### PR DESCRIPTION
Error seemed to be that `shake` was undefined for NOT nodes. I have no idea why that would be the case, as it should have inherited from BaseNode, but it's fixed now.